### PR TITLE
update imports and arguments for smac 0.11.0 + some fixes to how the tae is given to the SMAC4AC class

### DIFF
--- a/acclingo/acclingo.py
+++ b/acclingo/acclingo.py
@@ -2,7 +2,7 @@ import inspect
 import logging
 import importlib.util
 
-from smac.facade.smac_facade import SMAC
+from smac.facade.smac_ac_facade import SMAC4AC
 from smac.intensification.intensification import Intensifier
 from smac.scenario.scenario import Scenario
 
@@ -34,23 +34,22 @@ class ACClingo(object):
         root_logger.setLevel(args_.verbose_level)
         
         scen = Scenario(scen_opts)
+
+        tae_args = {"ta_bin": args_.binary, "runsolver_bin": args_.runsolver, 
+                "memlimit": args_.memlimit,
+                "run_obj": args_.run_obj,
+                "par_factor": 10,
+                "misc": args_.tae_args}
         
         if args_.tae_class:
             spec = importlib.util.spec_from_file_location("tae",args_.tae_class)
             tae_module = importlib.util.module_from_spec(spec)
             spec.loader.exec_module(tae_module)
             tae_class = inspect.getmembers(tae_module, inspect.isclass)[0][1]
-            ctae = tae_class(ta_bin=args_.binary, runsolver_bin=args_.runsolver, 
-                            memlimit=args_.memlimit,
-                            run_obj=args_.run_obj,
-                            par_factor=10,
-                            misc=args_.tae_args)
+
         else:
-            ctae = ClaspTAE(ta_bin=args_.binary, runsolver_bin=args_.runsolver, 
-                            memlimit=args_.memlimit,
-                            run_obj=args_.run_obj,
-                            par_factor=10,
-                            misc=args_.tae_args)
-        
-        smac = SMAC(scenario=scen, rng=args_.seed, tae_runner=ctae)
+            tae_class = ClaspTAE
+            
+        smac = SMAC4AC(scenario=scen, rng=args_.seed, tae_runner=tae_class, tae_runner_kwargs=tae_args)
+
         conf = smac.optimize()

--- a/acclingo/tae/asprin_tae.py
+++ b/acclingo/tae/asprin_tae.py
@@ -7,6 +7,8 @@ from subprocess import Popen, PIPE
 from smac.tae.execute_ta_run import StatusType, ExecuteTARun
 from smac.stats.stats import Stats
 from smac.runhistory.runhistory import RunHistory
+from smac.utils.constants import MAXINT
+
 from tempfile import NamedTemporaryFile
 
 __author__ = "Marius Lindauer"
@@ -14,14 +16,17 @@ __license__ = "3-clause BSD"
 
 float_regex = '[+-]?\d+(?:\.\d+)?(?:[eE][+-]\d+)?'
 
-class ClaspTAE(ExecuteTARun):
+class AsprinTAE(ExecuteTARun):
 
     
-    def __init__(self, ta_bin:str, runsolver_bin:str, 
+    def __init__(self, ta_bin:str, runsolver_bin:str,
+                 ta=None, 
                  memlimit:int=2048,
                  stats:Stats=None, runhistory:RunHistory=None, 
                  run_obj:str="runtime",
                  par_factor=10,
+                 cost_for_crash: float=float(MAXINT),
+                 abort_on_first_run_crash: bool=True,
                  misc=dict()
                  ):
         """
@@ -46,10 +51,13 @@ class ClaspTAE(ExecuteTARun):
             par_factor: int
                 penalized average runtime factor
         """
-        super().__init__(ta=None,
+        super().__init__(ta=ta,
                          stats=stats, runhistory=runhistory, 
                          run_obj=run_obj,
-                         par_factor=par_factor)
+                         par_factor=par_factor,
+                         cost_for_crash=cost_for_crash,
+                         abort_on_first_run_crash=abort_on_first_run_crash)
+        
         
         self.ta_bin = ta_bin
         self.runsolver_bin = runsolver_bin

--- a/acclingo/tae/clasp_opt_tae.py
+++ b/acclingo/tae/clasp_opt_tae.py
@@ -7,6 +7,8 @@ from subprocess import Popen, PIPE
 from smac.tae.execute_ta_run import StatusType, ExecuteTARun
 from smac.stats.stats import Stats
 from smac.runhistory.runhistory import RunHistory
+from smac.utils.constants import MAXINT
+
 from tempfile import NamedTemporaryFile
 
 __author__ = "Marius Lindauer"
@@ -17,11 +19,14 @@ float_regex = '[+-]?\d+(?:\.\d+)?(?:[eE][+-]\d+)?'
 class ClaspOptTAE(ExecuteTARun):
 
     
-    def __init__(self, ta_bin:str, runsolver_bin:str, 
+    def __init__(self, ta_bin:str, runsolver_bin:str,
+                 ta=None, 
                  memlimit:int=2048,
                  stats:Stats=None, runhistory:RunHistory=None, 
                  run_obj:str="runtime",
                  par_factor=10,
+                 cost_for_crash: float=float(MAXINT),
+                 abort_on_first_run_crash: bool=True,
                  misc=dict()
                  ):
         """
@@ -46,10 +51,12 @@ class ClaspOptTAE(ExecuteTARun):
             par_factor: int
                 penalized average runtime factor
         """
-        super().__init__(ta=None,
+        super().__init__(ta=ta,
                          stats=stats, runhistory=runhistory, 
                          run_obj=run_obj,
-                         par_factor=par_factor)
+                         par_factor=par_factor,
+                         cost_for_crash=cost_for_crash,
+                         abort_on_first_run_crash=abort_on_first_run_crash)
         
         self.ta_bin = ta_bin
         self.runsolver_bin = runsolver_bin

--- a/acclingo/tae/clasp_opt_weights_tae.py
+++ b/acclingo/tae/clasp_opt_weights_tae.py
@@ -7,6 +7,8 @@ from subprocess import Popen, PIPE
 from smac.tae.execute_ta_run import StatusType, ExecuteTARun
 from smac.stats.stats import Stats
 from smac.runhistory.runhistory import RunHistory
+from smac.utils.constants import MAXINT
+
 from tempfile import NamedTemporaryFile
 
 __author__ = "Marius Lindauer"
@@ -17,11 +19,14 @@ float_regex = '[+-]?\d+(?:\.\d+)?(?:[eE][+-]\d+)?'
 class ClaspOptTAE(ExecuteTARun):
 
     
-    def __init__(self, ta_bin:str, runsolver_bin:str, 
+    def __init__(self, ta_bin:str, runsolver_bin:str,
+                 ta=None, 
                  memlimit:int=2048,
                  stats:Stats=None, runhistory:RunHistory=None, 
                  run_obj:str="runtime",
                  par_factor=10,
+                 cost_for_crash: float=float(MAXINT),
+                 abort_on_first_run_crash: bool=True,
                  misc=dict()
                  ):
         """
@@ -52,11 +57,13 @@ class ClaspOptTAE(ExecuteTARun):
                     "penalty" : float
                     "normalized": bool
         """
-        super().__init__(ta=None,
+        super().__init__(ta=ta,
                          stats=stats, runhistory=runhistory, 
                          run_obj=run_obj,
-                         par_factor=par_factor)
-        
+                         par_factor=par_factor,
+                         cost_for_crash=cost_for_crash,
+                         abort_on_first_run_crash=abort_on_first_run_crash)
+
         self.ta_bin = ta_bin
         self.runsolver_bin = runsolver_bin
         self.memlimit = memlimit

--- a/acclingo/tae/clasp_tae.py
+++ b/acclingo/tae/clasp_tae.py
@@ -7,6 +7,8 @@ from subprocess import Popen, PIPE
 from smac.tae.execute_ta_run import StatusType, ExecuteTARun
 from smac.stats.stats import Stats
 from smac.runhistory.runhistory import RunHistory
+from smac.utils.constants import MAXINT
+
 from tempfile import NamedTemporaryFile
 
 __author__ = "Marius Lindauer"
@@ -17,11 +19,14 @@ float_regex = '[+-]?\d+(?:\.\d+)?(?:[eE][+-]\d+)?'
 class ClaspTAE(ExecuteTARun):
 
     
-    def __init__(self, ta_bin:str, runsolver_bin:str, 
+    def __init__(self, ta_bin:str, runsolver_bin:str,
+                 ta=None, 
                  memlimit:int=2048,
                  stats:Stats=None, runhistory:RunHistory=None, 
                  run_obj:str="runtime",
                  par_factor=10,
+                 cost_for_crash: float=float(MAXINT),
+                 abort_on_first_run_crash: bool=True,
                  misc=dict()
                  ):
         """
@@ -46,10 +51,12 @@ class ClaspTAE(ExecuteTARun):
             par_factor: int
                 penalized average runtime factor
         """
-        super().__init__(ta=None,
+        super().__init__(ta=ta,
                          stats=stats, runhistory=runhistory, 
                          run_obj=run_obj,
-                         par_factor=par_factor)
+                         par_factor=par_factor,
+                         cost_for_crash=cost_for_crash,
+                         abort_on_first_run_crash=abort_on_first_run_crash)
         
         self.ta_bin = ta_bin
         self.runsolver_bin = runsolver_bin


### PR DESCRIPTION
Changes on acclingo.py:
- Fix import to smac facade
- TAE class and TAE arguments are now given to SMAC4AC as arguments instead of passing a TAE class already instantiated

Changes in all TAE files:
- add the arguments ta, cost_for_crash and abort_on_first_run_crash to all TAE classes
- add the new arguments to the super().__init__(...) call
- add import of MAXINT